### PR TITLE
#4,  #5 typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ return {
     "ethanamaher/better-git-blame.nvim",
 
     dependencies = {
-        "nvim-lua-plenary/nvim",
+        "nvim-lua/plenary.nvim",
         "nvim-telescope/telescope.nvim",
         -- Optional but highly recommended
         -- "tpope/vim-fugitive"
         -- "sindrets/diffview.nvim"
-
     },
 
     config = function()

--- a/lua/better-git-blame/git.lua
+++ b/lua/better-git-blame/git.lua
@@ -1,46 +1,47 @@
 -- lua/better-git-blame/git.lua
-
 local M = {}
 
 local Job = require("plenary.job")
 local Path = require("plenary.path")
 
+---format and date arugments for git log commands
 local format_arg = "--format=%H %ad %an %s"
 local date_arg = "--date=format:%Y-%m-%d %H:%M:%S"
 
--- find git repo root
--- runs git rev-parse --show-toplevel from parent dir.
--- TODO check if current_path is file
--- if file do parent():absolute()
--- else for :absolute()
+---find absolute path to root directory of a git repo
+---@param current_path string absolute path to file withing git repo
+---@return string|nil absolute path to git repo root
 function M.find_git_repo_root(current_path)
-    local parent_dir = Path:new(current_path):parent():absolute()
-    if not parent_dir then
-        vim.notify("Could not get parent directory for: " .. tostring(current_path), vim.log.levels.ERROR, { title="BetterGitBlame" })
-        return
+    local parent_dir_path = Path:new(current_path):parent():absolute()
+    if not parent_dir_path then
+        vim.notify("Could not get parent directory for: " .. tostring(current_path), vim.log.levels.ERROR,
+            { title = "BetterGitBlame" })
+        return nil
     end
 
-    local repo_root_cmd = { "git", "-C", vim.fn.fnameescape(parent_dir), "rev-parse", "--show-toplevel" }
+    local repo_root_cmd = { "git", "-C", vim.fn.fnameescape(parent_dir_path), "rev-parse", "--show-toplevel" }
     local repo_root_list = vim.fn.systemlist(repo_root_cmd)
-    local repo_root = repo_root_list and repo_root_list[1]
 
     if vim.vshell_error ~= nil then
-        if repo_root == "" then repo_root = nil end -- handle empty output
-        vim.notify("ERROR HERE", vim.log.levels.ERROR, { title="BetterGitBlame" })
+        vim.notify("git rev-parse command failed in %s" .. tostring(parent_dir_path), vim.log.levels.ERROR, { title = "BetterGitBlame" })
+        return nil
     end
 
+    local repo_root = repo_root_list and #repo_root_list > 0 and vim.trim(repo_root_list[1])
     if not repo_root then
-        vim.notify("Could not determine Git repository root. " .. tostring(parent_dir) .. " from " .. tostring(current_path), vim.log.levels.ERROR, { title="BetterGitBlame"})
+        vim.notify(
+            "Could not determine Git repository root. " ..
+            "Command 'git -C \"" .. parent_dir_path .. "\" rev-parse --show-toplevel' returned no output",
+            vim.log.levels.WARN, { title = "BetterGitBlame" })
+        return nil
     end
+    print(repo_root)
     return repo_root
 end
 
--- parse output of git log
--- put into table with each element.
--- must be used with hardcoded format and date arguments
---
--- --format=%H %ad %an %s
--- --date=format:%Y-%m-%d %H:%M:%S
+---parse output from git log command
+---@param output_lines table list of strings that is output from git log
+---@return table list of commit objects with fields hash, date, time, author, message
 function M.parse_git_log(output_lines)
     local commits = {}
 
@@ -55,21 +56,23 @@ function M.parse_git_log(output_lines)
                 date = date,
                 time = time,
                 author = author,
-                message = message, -- commit message (denoted subject from git log)
+                message = message, -- commit message (subject from git log)
             })
         end
     end
     return commits
 end
 
--- driver function for BlameInvestigateLines
--- git log -L<start>:<end>
--- output of git log is parsed into commit_list table and returned
+--- driver function for BlameInvestigateLines
+---@param selection table contains selection details: { filename, start_line, end_line }
+---@param repo_root string absolute path to git repo root
+---@param callback function function to call upon completion
 function M.get_commits_by_line(selection, repo_root, callback)
-    local current_path = Path:new(selection.file)
+    local current_path = Path:new(selection.filename)
     local rel_file_path = current_path:make_relative(repo_root)
     if not rel_file_path then
-        vim.notify("could not find relative file path", vim.log.levels.ERROR, { title="BetterGitBlame" })
+        vim.notify("could not determin relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
+        callback(nil, "could not determine relative file path")
         return
     end
 
@@ -87,7 +90,7 @@ function M.get_commits_by_line(selection, repo_root, callback)
             -- return val other than 0, consider error
             if return_val ~= 0 then
                 local stderr = table.concat(j:stderr_result(), "\n")
-                vim.notify("git log failed".. stderr , vim.log.levels.ERROR, { title="BetterGitBlame"})
+                vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
                 callback(nil, stderr)
                 return
             end
@@ -95,23 +98,25 @@ function M.get_commits_by_line(selection, repo_root, callback)
             local commit_list = M.parse_git_log(j:result())
             -- no commit list
             if #commit_list == 0 then
-                vim.notify("No commits", vim.log.levels.WARN, { title="BetterGitBlame" })
-                -- callback with empty list
+                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+                -- fallthrough callback with empty list
             end
             callback(commit_list, nil)
         end),
     }):start()
 end
 
--- driver function for BlameInvestigateContent
--- git log -G<regex>
--- output of git log is parsed into commit_list table and returned
+--- driver function for BlameInvestigateContent
+---@param selection table contains selection details: { filename, start_line, end_line }
+---@param repo_root string absolute path to git repo root
+---@param search_term string POSIX ERE search term regex
+---@param callback function function to call upon completion
 function M.get_commits_by_search_term(selection, repo_root, search_term, callback)
-    local current_path = Path:new(selection.file)
+    local current_path = Path:new(selection.filename)
     local rel_file_path = current_path:make_relative(repo_root)
     if not rel_file_path then
-        vim.notify("could not find relative file path", vim.log.levels.ERROR, { title="BetterGitBlame" })
-        callback(nil, "Relative path error")
+        vim.notify("could not determine relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
+        callback(nil, "could not determine relative file path")
         return
     end
 
@@ -120,6 +125,8 @@ function M.get_commits_by_search_term(selection, repo_root, search_term, callbac
 
     local git_args = { "-C", repo_root, "log", search_arg_option, format_arg, date_arg, "--", rel_file_path }
 
+    -- TODO refactor this job into helper function
+    -- essentially gets called by every get commits by
     Job:new({
         command = "git",
         args = git_args,
@@ -127,14 +134,17 @@ function M.get_commits_by_search_term(selection, repo_root, search_term, callbac
         on_exit = vim.schedule_wrap(function(j, return_val)
             local stderr_lines = j:stderr_result()
             local stderr = stderr_lines and table.concat(stderr_lines, "\n") or ""
+
             if return_val ~= 0 then
-                vim.notify("git log %s failed: %s".. search_description, stderr, vim.log.levels.ERROR, { title="BetterGitBlame"})
+                vim.notify("git log %s failed: %s" .. search_description, stderr, vim.log.levels.ERROR,
+                    { title = "BetterGitBlame" })
                 callback(nil, stderr)
                 return
             end
 
             if stderr:match("fatal: ambiguous argument") or stderr:match("fatal: bad revision") or stderr:match("Invalid regular expression") then
-                vim.notify("git log %s fatal error: %s".. search_description, stderr, vim.log.levels.ERROR, { title="BetterGitBlame"})
+                vim.notify("git log %s fatal error: %s" .. search_description, stderr, vim.log.levels.ERROR,
+                    { title = "BetterGitBlame" })
                 callback(nil, stderr)
                 return
             end
@@ -142,80 +152,70 @@ function M.get_commits_by_search_term(selection, repo_root, search_term, callbac
             local commit_list = M.parse_git_log(j:result())
 
             if #commit_list == 0 then
-                vim.notify("No commits", vim.log.levels.WARN, { title="BetterGitBlame" })
-                -- callback with empty list
+                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+                -- fallthrough callback with empty list
             end
             callback(commit_list, nil)
         end),
     }):start()
 end
 
--- driver function for BlameInvestigateFunction
--- git log -L:<func_name>:<filename>
--- output of git log is parsed into commit_list table and returned
+---driver function for BlameInvestigateFunction
+---@param selection table contains selection details: { filename, start_line, end_line }
+---@param repo_root string absolute path to git repo root
+---@param function_names table list of function name strings to search for
+---@param callback function function to call upon completion
 function M.get_commits_by_func_name(selection, repo_root, function_names, callback)
     -- relative file path for git log arg
-    local current_path = Path:new(selection.file)
+    local current_path = Path:new(selection.filename)
     local rel_file_path = current_path:make_relative(repo_root)
     if not rel_file_path then
-        vim.notify("could not find relative file path", vim.log.levels.ERROR, { title="BetterGitBlame" })
+        vim.notify("could not find relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
         return
     end
 
-    local commit_list = {}
-    local commit_list_set = {}
-
+    -- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
+    local git_args = { "-C", repo_root, "log"}
     for _, function_name in ipairs(function_names) do
-        local range_arg = "-L:" .. function_name .. ":" .. rel_file_path
-
-        -- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
-        local git_args = { "-C", repo_root, "log", range_arg, format_arg, date_arg }
-        vim.notify("Searching Git history for selection...", vim.log.levels.INFO, { title="BetterGitBlame" })
-
-
-        Job:new({
-            command = "git",
-            args = git_args,
-            cwd = repo_root,
-            on_exit = vim.schedule_wrap(function(j, return_val)
-                -- return val other than 0, consider error
-                if return_val ~= 0 then
-                    local stderr = table.concat(j:stderr_result(), "\n")
-                    vim.notify("git log failed".. stderr , vim.log.levels.ERROR, { title="BetterGitBlame"})
-                    callback(nil, stderr)
-                    return
-                end
-
-                local commit_list_function = M.parse_git_log(j:result()) -- should never be nil
-                for _, commit in ipairs(commit_list_function) do
-                    if not commit_list_set[commit.hash] then
-                        table.insert(commit_list, commit)
-                        commit_list_set[commit.hash] = true
-                    else
-                        vim.notify("Not insert hash: " .. commit.hash, vim.log.levels.INFO, { title="BetterGirBlame:BlameInvestigateFunction" })
-                    end
-                end
-
-                -- no commit list
-                if #commit_list_function == 0 then
-                    vim.notify("No commits", vim.log.levels.WARN, { title="BetterGitBlame" })
-                    -- callback with empty list
-                end
-
-                callback(commit_list, nil)
-            end),
-        }):start()
+        table.insert(git_args, "-L:" .. function_name .. ":" .. rel_file_path)
     end
+    table.insert(git_args, format_arg)
+    table.insert(git_args, date_arg)
+    --table.insert(git_args, "--")
+    vim.notify("Searching Git history for selection...", vim.log.levels.INFO, { title = "BetterGitBlame" })
+
+    Job:new({
+        command = "git",
+        args = git_args,
+        cwd = repo_root,
+        on_exit = vim.schedule_wrap(function(j, return_val)
+            -- return val other than 0, consider error
+            if return_val ~= 0 then
+                local stderr = table.concat(j:stderr_result(), "\n")
+                vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
+                callback(nil, stderr)
+                return
+            end
+
+            local commit_list = M.parse_git_log(j:result()) -- should never be nil
+
+            -- no commit list
+            if #commit_list == 0 then
+                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+                -- callback with empty list
+            end
+
+            callback(commit_list, nil)
+        end),
+    }):start()
 end
 
--- used for getting diff output from commit hash
--- git show <hash>
+---used for getting diff output from commit hash
+---@param repo_root string absolute path to git repo root
+---@param commit_hash string commit hash to get details for
+---@param callback function function to call upon completion
 function M.get_commit_details(repo_root, commit_hash, callback)
     local diff_args = { "show", commit_hash }
-
-    local diff_output = {}
-    local error_output = {}
-    local exit_code = -1
 
     -- git show <hash>
     Job:new({
@@ -223,31 +223,34 @@ function M.get_commit_details(repo_root, commit_hash, callback)
         args = diff_args,
         cwd = repo_root,
 
-        on_stdout = function(_, data) if data then table.insert(diff_output, data) end end,
-        on_stderr = function(_, data) if data then table.insert(error_output, data) end end,
-
         on_exit = vim.schedule_wrap(function(j, return_val)
-            exit_code = return_val
+            local stdout_lines = j:result() or {}
+            local stderr_lines = j:stderr_result() or {}
             if return_val ~= 0 then
-                vim.notify("git show failed for diff: " .. commit_hash, vim.log.levels.WARN, { title="BetterGitBlame"})
+                vim.notify("git show failed for diff: " .. commit_hash, vim.log.levels.WARN, { title = "BetterGitBlame" })
             end
-            callback(diff_output, error_output, exit_code)
+            callback(stdout_lines, stderr_lines, return_val)
         end),
     }):start()
 end
 
+---get the remote url from a git repo
+---@param repo_root string absolute path to git repo root
+---@return string|nil the remote URL, nil if not found or error
 local function get_git_remote_url(repo_root)
-    local args = { "git", "-C", repo_root,  "remote", "get-url", "origin" }
+    local args = { "git", "-C", repo_root, "remote", "get-url", "origin" }
     local result = vim.fn.systemlist(args)
-    if result then
+    if vim.vshell_error == 0 and result and #result > 0 and result[1]
+            and vim.trim(result[1]) ~= "" then
         return vim.trim(result[1])
     end
 
     return nil
 end
 
--- parse a remote url from get_git_remote_url
--- should work for both ssh and https urls
+---helper function to parse a remote url from get_git_remote_url
+---@param url string git remote url
+---@return table|nil a table { host = string, path = string } or nil if parsing fails
 local function parse_git_url(url)
     -- try ssh format
     local ssh_host, ssh_path = url:match("^git@([^:]+):(.+)$")
@@ -270,20 +273,24 @@ local function parse_git_url(url)
     return nil
 end
 
+---@param repo_root string absolute path to git repo root
+---@param commit_hash string commit hash to get details for
 function M.open_commit_in_browser(repo_root, commit_hash)
     local remote_url = get_git_remote_url(repo_root)
     if not remote_url then
-        vim.notify("Could not determine remote URL: ", vim.log.levels.WARN, { title="BetterGitBlame:OpenCommitInBrowser" })
+        vim.notify("Could not determine remote URL: ", vim.log.levels.WARN,
+            { title = "BetterGitBlame:OpenCommitInBrowser" })
         return
     end
 
     local parsed_url = parse_git_url(remote_url)
     if not parsed_url then
-        vim.notify("Could not parse remote URL: " .. parsed_url, vim.log.levels.WARN, { title="BetterGitBlame:OpenCommitInBrowser" })
+        vim.notify("Could not parse remote URL: " .. parsed_url, vim.log.levels.WARN,
+            { title = "BetterGitBlame:OpenCommitInBrowser" })
         return
     end
 
-    local commit_url = nil
+    local commit_url
     local host = parsed_url.host:lower()
     local path = parsed_url.path
 
@@ -291,7 +298,8 @@ function M.open_commit_in_browser(repo_root, commit_hash)
     if host:find("github.com") then
         commit_url = string.format("https://%s/%s/commit/%s", host, path, commit_hash)
     else
-        vim.notify("Unsupported git host: " .. parsed_url.host, vim.log.levels.WARN, { title="BetterGitBlame:OpenCommitInBrowser" })
+        vim.notify("Unsupported git host: " .. parsed_url.host, vim.log.levels.WARN,
+            { title = "BetterGitBlame:OpenCommitInBrowser" })
         return
     end
 
@@ -303,7 +311,7 @@ function M.open_commit_in_browser(repo_root, commit_hash)
 
         on_exit = function(_, code)
             if code ~= 0 then
-                vim.notify("Failed to open URL.", vim.log.levels.ERROR, { title="BetterGitBlame:OpenCommitInBrowser" })
+                vim.notify("Failed to open URL.", vim.log.levels.ERROR, { title = "BetterGitBlame:OpenCommitInBrowser" })
             end
         end
     }):start()

--- a/lua/better-git-blame/git.lua
+++ b/lua/better-git-blame/git.lua
@@ -12,55 +12,66 @@ local date_arg = "--date=format:%Y-%m-%d %H:%M:%S"
 ---@param current_path string absolute path to file withing git repo
 ---@return string|nil absolute path to git repo root
 function M.find_git_repo_root(current_path)
-    local parent_dir_path = Path:new(current_path):parent():absolute()
-    if not parent_dir_path then
-        vim.notify("Could not get parent directory for: " .. tostring(current_path), vim.log.levels.ERROR,
-            { title = "BetterGitBlame" })
-        return nil
-    end
+	local parent_dir_path = Path:new(current_path):parent():absolute()
+	if not parent_dir_path then
+		vim.notify(
+			"Could not get parent directory for: " .. tostring(current_path),
+			vim.log.levels.ERROR,
+			{ title = "BetterGitBlame" }
+		)
+		return nil
+	end
 
-    local repo_root_cmd = { "git", "-C", vim.fn.fnameescape(parent_dir_path), "rev-parse", "--show-toplevel" }
-    local repo_root_list = vim.fn.systemlist(repo_root_cmd)
+	local repo_root_cmd = { "git", "-C", vim.fn.fnameescape(parent_dir_path), "rev-parse", "--show-toplevel" }
+	local repo_root_list = vim.fn.systemlist(repo_root_cmd)
 
-    if vim.vshell_error ~= nil then
-        vim.notify("git rev-parse command failed in %s" .. tostring(parent_dir_path), vim.log.levels.ERROR, { title = "BetterGitBlame" })
-        return nil
-    end
+	if vim.vshell_error ~= nil then
+		vim.notify(
+			"git rev-parse command failed in %s" .. tostring(parent_dir_path),
+			vim.log.levels.ERROR,
+			{ title = "BetterGitBlame" }
+		)
+		return nil
+	end
 
-    local repo_root = repo_root_list and #repo_root_list > 0 and vim.trim(repo_root_list[1])
-    if not repo_root then
-        vim.notify(
-            "Could not determine Git repository root. " ..
-            "Command 'git -C \"" .. parent_dir_path .. "\" rev-parse --show-toplevel' returned no output",
-            vim.log.levels.WARN, { title = "BetterGitBlame" })
-        return nil
-    end
-    print(repo_root)
-    return repo_root
+	local repo_root = repo_root_list and #repo_root_list > 0 and vim.trim(repo_root_list[1])
+	if not repo_root then
+		vim.notify(
+			"Could not determine Git repository root. "
+				.. "Command 'git -C \""
+				.. parent_dir_path
+				.. "\" rev-parse --show-toplevel' returned no output",
+			vim.log.levels.WARN,
+			{ title = "BetterGitBlame" }
+		)
+		return nil
+	end
+	print(repo_root)
+	return repo_root
 end
 
 ---parse output from git log command
 ---@param output_lines table list of strings that is output from git log
 ---@return table list of commit objects with fields hash, date, time, author, message
 function M.parse_git_log(output_lines)
-    local commits = {}
+	local commits = {}
 
-    -- <hash> <date> <author> <subject>
-    local pattern = "^([0-9a-f]+)%s+([%d-]+)%s+([%d:]+)%s+(.-)%s+(.*)$"
+	-- <hash> <date> <author> <subject>
+	local pattern = "^([0-9a-f]+)%s+([%d-]+)%s+([%d:]+)%s+(.-)%s+(.*)$"
 
-    for _, line in ipairs(output_lines) do
-        local hash, date, time, author, message = line:match(pattern)
-        if hash and date and time and author and message then
-            table.insert(commits, {
-                hash = hash,
-                date = date,
-                time = time,
-                author = author,
-                message = message, -- commit message (subject from git log)
-            })
-        end
-    end
-    return commits
+	for _, line in ipairs(output_lines) do
+		local hash, date, time, author, message = line:match(pattern)
+		if hash and date and time and author and message then
+			table.insert(commits, {
+				hash = hash,
+				date = date,
+				time = time,
+				author = author,
+				message = message, -- commit message (subject from git log)
+			})
+		end
+	end
+	return commits
 end
 
 --- driver function for BlameInvestigateLines
@@ -68,42 +79,42 @@ end
 ---@param repo_root string absolute path to git repo root
 ---@param callback function function to call upon completion
 function M.get_commits_by_line(selection, repo_root, callback)
-    local current_path = Path:new(selection.filename)
-    local rel_file_path = current_path:make_relative(repo_root)
-    if not rel_file_path then
-        vim.notify("could not determin relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
-        callback(nil, "could not determine relative file path")
-        return
-    end
+	local current_path = Path:new(selection.filename)
+	local rel_file_path = current_path:make_relative(repo_root)
+	if not rel_file_path then
+		vim.notify("could not determin relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
+		callback(nil, "could not determine relative file path")
+		return
+	end
 
-    local log_range = string.format("%d,%d", selection.start_line, selection.end_line)
-    local range_arg = "-L" .. log_range .. ":" .. rel_file_path
+	local log_range = string.format("%d,%d", selection.start_line, selection.end_line)
+	local range_arg = "-L" .. log_range .. ":" .. rel_file_path
 
-    -- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
-    local git_args = { "-C", repo_root, "log", range_arg, format_arg, date_arg }
+	-- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
+	local git_args = { "-C", repo_root, "log", range_arg, format_arg, date_arg }
 
-    Job:new({
-        command = "git",
-        args = git_args,
-        cwd = repo_root,
-        on_exit = vim.schedule_wrap(function(j, return_val)
-            -- return val other than 0, consider error
-            if return_val ~= 0 then
-                local stderr = table.concat(j:stderr_result(), "\n")
-                vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
-                callback(nil, stderr)
-                return
-            end
+	Job:new({
+		command = "git",
+		args = git_args,
+		cwd = repo_root,
+		on_exit = vim.schedule_wrap(function(j, return_val)
+			-- return val other than 0, consider error
+			if return_val ~= 0 then
+				local stderr = table.concat(j:stderr_result(), "\n")
+				vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
+				callback(nil, stderr)
+				return
+			end
 
-            local commit_list = M.parse_git_log(j:result())
-            -- no commit list
-            if #commit_list == 0 then
-                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
-                -- fallthrough callback with empty list
-            end
-            callback(commit_list, nil)
-        end),
-    }):start()
+			local commit_list = M.parse_git_log(j:result())
+			-- no commit list
+			if #commit_list == 0 then
+				vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+				-- fallthrough callback with empty list
+			end
+			callback(commit_list, nil)
+		end),
+	}):start()
 end
 
 --- driver function for BlameInvestigateContent
@@ -112,52 +123,64 @@ end
 ---@param search_term string POSIX ERE search term regex
 ---@param callback function function to call upon completion
 function M.get_commits_by_search_term(selection, repo_root, search_term, callback)
-    local current_path = Path:new(selection.filename)
-    local rel_file_path = current_path:make_relative(repo_root)
-    if not rel_file_path then
-        vim.notify("could not determine relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
-        callback(nil, "could not determine relative file path")
-        return
-    end
+	local current_path = Path:new(selection.filename)
+	local rel_file_path = current_path:make_relative(repo_root)
+	if not rel_file_path then
+		vim.notify("could not determine relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
+		callback(nil, "could not determine relative file path")
+		return
+	end
 
-    local search_arg_option = "-G" .. search_term
-    local search_description = "regex -G"
+	local search_arg_option = "-G" .. search_term
+	local search_description = "regex -G"
 
-    local git_args = { "-C", repo_root, "log", search_arg_option, format_arg, date_arg, "--", rel_file_path }
+	local git_args = { "-C", repo_root, "log", search_arg_option, format_arg, date_arg, "--", rel_file_path }
 
-    -- TODO refactor this job into helper function
-    -- essentially gets called by every get commits by
-    Job:new({
-        command = "git",
-        args = git_args,
-        cwd = repo_root,
-        on_exit = vim.schedule_wrap(function(j, return_val)
-            local stderr_lines = j:stderr_result()
-            local stderr = stderr_lines and table.concat(stderr_lines, "\n") or ""
+	-- TODO refactor this job into helper function
+	-- essentially gets called by every get commits by
+	Job:new({
+		command = "git",
+		args = git_args,
+		cwd = repo_root,
+		on_exit = vim.schedule_wrap(function(j, return_val)
+			local stderr_lines = j:stderr_result()
+			local stderr = stderr_lines and table.concat(stderr_lines, "\n") or ""
 
-            if return_val ~= 0 then
-                vim.notify("git log %s failed: %s" .. search_description, stderr, vim.log.levels.ERROR,
-                    { title = "BetterGitBlame" })
-                callback(nil, stderr)
-                return
-            end
+			if return_val ~= 0 then
+				vim.notify(
+					"git log %s failed: %s" .. search_description,
+					stderr,
+					vim.log.levels.ERROR,
+					{ title = "BetterGitBlame" }
+				)
+				callback(nil, stderr)
+				return
+			end
 
-            if stderr:match("fatal: ambiguous argument") or stderr:match("fatal: bad revision") or stderr:match("Invalid regular expression") then
-                vim.notify("git log %s fatal error: %s" .. search_description, stderr, vim.log.levels.ERROR,
-                    { title = "BetterGitBlame" })
-                callback(nil, stderr)
-                return
-            end
+			if
+				stderr:match("fatal: ambiguous argument")
+				or stderr:match("fatal: bad revision")
+				or stderr:match("Invalid regular expression")
+			then
+				vim.notify(
+					"git log %s fatal error: %s" .. search_description,
+					stderr,
+					vim.log.levels.ERROR,
+					{ title = "BetterGitBlame" }
+				)
+				callback(nil, stderr)
+				return
+			end
 
-            local commit_list = M.parse_git_log(j:result())
+			local commit_list = M.parse_git_log(j:result())
 
-            if #commit_list == 0 then
-                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
-                -- fallthrough callback with empty list
-            end
-            callback(commit_list, nil)
-        end),
-    }):start()
+			if #commit_list == 0 then
+				vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+				-- fallthrough callback with empty list
+			end
+			callback(commit_list, nil)
+		end),
+	}):start()
 end
 
 ---driver function for BlameInvestigateFunction
@@ -166,48 +189,48 @@ end
 ---@param function_names table list of function name strings to search for
 ---@param callback function function to call upon completion
 function M.get_commits_by_func_name(selection, repo_root, function_names, callback)
-    -- relative file path for git log arg
-    local current_path = Path:new(selection.filename)
-    local rel_file_path = current_path:make_relative(repo_root)
-    if not rel_file_path then
-        vim.notify("could not find relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
-        return
-    end
+	-- relative file path for git log arg
+	local current_path = Path:new(selection.filename)
+	local rel_file_path = current_path:make_relative(repo_root)
+	if not rel_file_path then
+		vim.notify("could not find relative file path", vim.log.levels.ERROR, { title = "BetterGitBlame" })
+		return
+	end
 
-    -- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
-    local git_args = { "-C", repo_root, "log"}
-    for _, function_name in ipairs(function_names) do
-        table.insert(git_args, "-L:" .. function_name .. ":" .. rel_file_path)
-    end
-    table.insert(git_args, format_arg)
-    table.insert(git_args, date_arg)
-    --table.insert(git_args, "--")
-    vim.notify("Searching Git history for selection...", vim.log.levels.INFO, { title = "BetterGitBlame" })
+	-- git log -C <repo_root> -L "<start>,<end>:<relative_path>" --format="%H %ad %an %s" --date=short
+	local git_args = { "-C", repo_root, "log" }
+	for _, function_name in ipairs(function_names) do
+		table.insert(git_args, "-L:" .. function_name .. ":" .. rel_file_path)
+	end
+	table.insert(git_args, format_arg)
+	table.insert(git_args, date_arg)
+	--table.insert(git_args, "--")
+	vim.notify("Searching Git history for selection...", vim.log.levels.INFO, { title = "BetterGitBlame" })
 
-    Job:new({
-        command = "git",
-        args = git_args,
-        cwd = repo_root,
-        on_exit = vim.schedule_wrap(function(j, return_val)
-            -- return val other than 0, consider error
-            if return_val ~= 0 then
-                local stderr = table.concat(j:stderr_result(), "\n")
-                vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
-                callback(nil, stderr)
-                return
-            end
+	Job:new({
+		command = "git",
+		args = git_args,
+		cwd = repo_root,
+		on_exit = vim.schedule_wrap(function(j, return_val)
+			-- return val other than 0, consider error
+			if return_val ~= 0 then
+				local stderr = table.concat(j:stderr_result(), "\n")
+				vim.notify("git log failed" .. stderr, vim.log.levels.ERROR, { title = "BetterGitBlame" })
+				callback(nil, stderr)
+				return
+			end
 
-            local commit_list = M.parse_git_log(j:result()) -- should never be nil
+			local commit_list = M.parse_git_log(j:result()) -- should never be nil
 
-            -- no commit list
-            if #commit_list == 0 then
-                vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
-                -- callback with empty list
-            end
+			-- no commit list
+			if #commit_list == 0 then
+				vim.notify("No commits", vim.log.levels.INFO, { title = "BetterGitBlame" })
+				-- callback with empty list
+			end
 
-            callback(commit_list, nil)
-        end),
-    }):start()
+			callback(commit_list, nil)
+		end),
+	}):start()
 end
 
 ---used for getting diff output from commit hash
@@ -215,106 +238,122 @@ end
 ---@param commit_hash string commit hash to get details for
 ---@param callback function function to call upon completion
 function M.get_commit_details(repo_root, commit_hash, callback)
-    local diff_args = { "show", commit_hash }
+	local diff_args = { "show", commit_hash }
 
-    -- git show <hash>
-    Job:new({
-        command = "git",
-        args = diff_args,
-        cwd = repo_root,
+	-- git show <hash>
+	Job:new({
+		command = "git",
+		args = diff_args,
+		cwd = repo_root,
 
-        on_exit = vim.schedule_wrap(function(j, return_val)
-            local stdout_lines = j:result() or {}
-            local stderr_lines = j:stderr_result() or {}
-            if return_val ~= 0 then
-                vim.notify("git show failed for diff: " .. commit_hash, vim.log.levels.WARN, { title = "BetterGitBlame" })
-            end
-            callback(stdout_lines, stderr_lines, return_val)
-        end),
-    }):start()
+		on_exit = vim.schedule_wrap(function(j, return_val)
+			local stdout_lines = j:result() or {}
+			local stderr_lines = j:stderr_result() or {}
+			if return_val ~= 0 then
+				vim.notify(
+					"git show failed for diff: " .. commit_hash,
+					vim.log.levels.WARN,
+					{ title = "BetterGitBlame" }
+				)
+			end
+			callback(stdout_lines, stderr_lines, return_val)
+		end),
+	}):start()
 end
 
 ---get the remote url from a git repo
 ---@param repo_root string absolute path to git repo root
 ---@return string|nil the remote URL, nil if not found or error
 local function get_git_remote_url(repo_root)
-    local args = { "git", "-C", repo_root, "remote", "get-url", "origin" }
-    local result = vim.fn.systemlist(args)
-    if vim.vshell_error == 0 and result and #result > 0 and result[1]
-            and vim.trim(result[1]) ~= "" then
-        return vim.trim(result[1])
-    end
+	local args = { "git", "-C", repo_root, "remote", "get-url", "origin" }
+	local result = vim.fn.systemlist(args)
+	if vim.vshell_error == 0 and result and #result > 0 and result[1] and vim.trim(result[1]) ~= "" then
+		return vim.trim(result[1])
+	end
 
-    return nil
+	return nil
 end
 
 ---helper function to parse a remote url from get_git_remote_url
 ---@param url string git remote url
 ---@return table|nil a table { host = string, path = string } or nil if parsing fails
 local function parse_git_url(url)
-    -- try ssh format
-    local ssh_host, ssh_path = url:match("^git@([^:]+):(.+)$")
-    if ssh_host and ssh_path then
-        -- if optional .git at end of path, remove
-        if ssh_path:find(".git$") then
-            ssh_path = ssh_path:sub(1, -5)
-        end
-        return { host = ssh_host, path = ssh_path }
-    end
+	-- try ssh format
+	local ssh_host, ssh_path = url:match("^git@([^:]+):(.+)$")
+	if ssh_host and ssh_path then
+		-- if optional .git at end of path, remove
+		if ssh_path:find(".git$") then
+			ssh_path = ssh_path:sub(1, -5)
+		end
+		return { host = ssh_host, path = ssh_path }
+	end
 
-    -- try http/https format
-    -- should work but not tested other than in regex matcher. seems fine
-    local https_host, https_path = url:match("^http[s]?://([^/]+)(/.+)$")
-    if https_host and https_path then
-        -- remove leading '/' in https path
-        https_path = https_path:sub(2)
-        return { host = https_host, path = https_path }
-    end
-    return nil
+	-- try http/https format
+	-- should work but not tested other than in regex matcher. seems fine
+	local https_host, https_path = url:match("^http[s]?://([^/]+)(/.+)$")
+	if https_host and https_path then
+		-- remove leading '/' in https path
+		https_path = https_path:sub(2)
+		return { host = https_host, path = https_path }
+	end
+	return nil
 end
 
 ---@param repo_root string absolute path to git repo root
 ---@param commit_hash string commit hash to get details for
 function M.open_commit_in_browser(repo_root, commit_hash)
-    local remote_url = get_git_remote_url(repo_root)
-    if not remote_url then
-        vim.notify("Could not determine remote URL: ", vim.log.levels.WARN,
-            { title = "BetterGitBlame:OpenCommitInBrowser" })
-        return
-    end
+	local remote_url = get_git_remote_url(repo_root)
+	if not remote_url then
+		vim.notify(
+			"Could not determine remote URL: ",
+			vim.log.levels.WARN,
+			{ title = "BetterGitBlame:OpenCommitInBrowser" }
+		)
+		return
+	end
 
-    local parsed_url = parse_git_url(remote_url)
-    if not parsed_url then
-        vim.notify("Could not parse remote URL: " .. parsed_url, vim.log.levels.WARN,
-            { title = "BetterGitBlame:OpenCommitInBrowser" })
-        return
-    end
+	local parsed_url = parse_git_url(remote_url)
+	if not parsed_url then
+		vim.notify(
+			"Could not parse remote URL: " .. parsed_url,
+			vim.log.levels.WARN,
+			{ title = "BetterGitBlame:OpenCommitInBrowser" }
+		)
+		return
+	end
 
-    local commit_url
-    local host = parsed_url.host:lower()
-    local path = parsed_url.path
+	local commit_url
+	local host = parsed_url.host:lower()
+	local path = parsed_url.path
 
-    -- TODO support other hosts
-    if host:find("github.com") then
-        commit_url = string.format("https://%s/%s/commit/%s", host, path, commit_hash)
-    else
-        vim.notify("Unsupported git host: " .. parsed_url.host, vim.log.levels.WARN,
-            { title = "BetterGitBlame:OpenCommitInBrowser" })
-        return
-    end
+	-- TODO support other hosts
+	if host:find("github.com") then
+		commit_url = string.format("https://%s/%s/commit/%s", host, path, commit_hash)
+	else
+		vim.notify(
+			"Unsupported git host: " .. parsed_url.host,
+			vim.log.levels.WARN,
+			{ title = "BetterGitBlame:OpenCommitInBrowser" }
+		)
+		return
+	end
 
-    -- use xdg-open to open the commit url in default browser
-    Job:new({
-        -- TODO support for non linux xdg-open
-        command = "xdg-open",
-        args = { commit_url },
+	-- use xdg-open to open the commit url in default browser
+	Job:new({
+		-- TODO support for non linux xdg-open
+		command = "xdg-open",
+		args = { commit_url },
 
-        on_exit = function(_, code)
-            if code ~= 0 then
-                vim.notify("Failed to open URL.", vim.log.levels.ERROR, { title = "BetterGitBlame:OpenCommitInBrowser" })
-            end
-        end
-    }):start()
+		on_exit = function(_, code)
+			if code ~= 0 then
+				vim.notify(
+					"Failed to open URL.",
+					vim.log.levels.ERROR,
+					{ title = "BetterGitBlame:OpenCommitInBrowser" }
+				)
+			end
+		end,
+	}):start()
 end
 
 return M

--- a/lua/better-git-blame/init.lua
+++ b/lua/better-git-blame/init.lua
@@ -8,21 +8,24 @@ local telescope_integration = require("better-git-blame.telescope")
 
 telescope_integration.setup_dependencies(git_utils)
 
--- used to store state of last commit_list and the information used to get it
+--- stores state of last investigation to be able to reopen
+--- with BlameShowLast
 local current_state = {
-    last_selection = nil,
-    last_repo_root = nil,
-    last_commit_list = nil,
-    last_search_term = nil,
+    last_selection = nil,   ---@type table|nil selection object from last investigation
+    last_repo_root = nil,   ---@type string|nil repository root from last investigation
+    last_commit_list = nil, ---@type table|nil list of commits from last investigation
+    last_search_term = nil, ---@type string|nil search term used if last search was content based
 }
 
--- function for :BlameInvestigateLines
+---Investigates the Git history for visually selected line
+---function for :BlameInvestigateLines
+---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_lines(args)
     -- get lines of visual selection
     local selection = selection_utils.get_visual_selection(args.line1, args.line2)
     if not selection then return end -- handled in get_visual_selection
 
-    local repo_root = git_utils.find_git_repo_root(selection.file)
+    local repo_root = git_utils.find_git_repo_root(selection.filename)
     if not repo_root then return end -- handled in find_git_repo_root
 
     -- update cached values for use in :BlameShowLast
@@ -32,25 +35,32 @@ function M.investigate_lines(args)
 
     git_utils.get_commits_by_line(selection, repo_root, function(commit_list, err)
         if err then
-            return
+            return -- error handled in get_commits_by_line
         end
 
         -- update cached commit list
-        current_state.last_commits = commit_list
+        current_state.last_commit_list = commit_list
         local title = string.format("Git History (Lines %d - %d)", selection.start_line, selection.end_line)
         telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
     end)
 end
 
--- function for :BlameInvestigateContent
+---Investigates the Git history for content matching visually selected text
+---function for :BlameInvestigateContent
+---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_content(args)
+    -- get lines of visual selection
     local selection, lines = selection_utils.get_visual_selection_content(args.line1, args.line2)
     if not selection then return end
 
-    local repo_root = git_utils.find_git_repo_root(selection.file)
+    local repo_root = git_utils.find_git_repo_root(selection.filename)
     if not repo_root then return end -- handled in find_git_repo_root
 
     local search_term = selection_utils.derive_regex_from_lines(lines)
+
+    if not search_term or search_term == "" then
+        return
+    end
 
     -- update cached values for use in :BlameShowLast
     current_state.last_selection = selection
@@ -58,7 +68,9 @@ function M.investigate_content(args)
     current_state.last_search_term = search_term
 
     git_utils.get_commits_by_search_term(selection, repo_root, search_term, function(commit_list, err)
-        if err then return end
+        if err then
+            return -- error handled in get_commits_by_search_term
+        end
         current_state.last_commit_list = commit_list
 
         local title = "Git History (Content Search)"
@@ -66,25 +78,16 @@ function M.investigate_content(args)
     end)
 end
 
--- function for :BlameShowLast
-function M.show_last_investigation()
-    if not current_state.last_selection or
-        not current_state.last_repo_root or
-        not current_state.last_commits then
-        vim.notify("Not previous investigation stored.", vim.log.levels.WARN, { title="BetterGitBlame:BlameShowLast" })
-        return
-    end
-    local title = string.format("Git History (%d - %d)", current_state.last_selection.start_line, current_state.last_selection.end_line)
-
-    telescope_integration.launch_telescope_picker(current_state.last_commits, current_state.last_repo_root, current_state.last_selection, title)
-end
-
--- function for :BlameInvestigateFunction
+---Investigates the Git history by identifying function names in the visually
+---     selected code block
+---function for :BlameInvestigateFunction
+---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_function_names(args)
+    -- get lines and function names from visual selection
     local selection, func_names = selection_utils.get_function_names_from_selection(args.line1, args.line2)
-    if not selection then return end
+    if not selection or not func_names or #func_names == 0 then return end
 
-    local repo_root = git_utils.find_git_repo_root(selection.file)
+    local repo_root = git_utils.find_git_repo_root(selection.filename)
     if not repo_root then return end -- handled in find_git_repo_root
 
     current_state.last_selection = selection
@@ -92,7 +95,9 @@ function M.investigate_function_names(args)
     current_state.last_search_term = nil
 
     git_utils.get_commits_by_func_name(selection, repo_root, func_names, function(commit_list, err)
-        if err then return end
+        if err then
+            return -- handled in get_commits_by_func_name
+        end
         current_state.last_commit_list = commit_list
 
         local title = string.format("Git History (function search)")
@@ -100,17 +105,30 @@ function M.investigate_function_names(args)
     end)
 end
 
--- setup all commands for BetterGitBlame
+---Opens the telescope picker with results of the last investigation
+---function for :BlameShowLast
+function M.show_last_investigation()
+    if not current_state.last_selection or
+        not current_state.last_repo_root or
+        not current_state.last_commit_list then
+        vim.notify("Not previous investigation stored.", vim.log.levels.WARN, { title = "BetterGitBlame:BlameShowLast" })
+        return
+    end
+    local title = string.format("Git History (%d - %d)", current_state.last_selection.start_line,
+        current_state.last_selection.end_line)
+
+    telescope_integration.launch_telescope_picker(current_state.last_commit_list, current_state.last_repo_root,
+        current_state.last_selection, title)
+end
+
+---Setups up user commands for BetterGitBlame plugin
 function M.setup()
     --config = vim.tbl_deep_extend("force", config, user_config or {})
 
-    vim.api.nvim_create_user_command("BlameInvestigatLines", M.investigate_lines, {
+    vim.api.nvim_create_user_command("BlameInvestigateLines", M.investigate_lines, {
         range = true,
-        desc = "Investigate Git history of selected code block by visually selecting lines. git log -L<start_line>:<end_line>",
-    })
-
-    vim.api.nvim_create_user_command("BlameShowLast", M.show_last_investigation, {
-        desc = "Show telescope picker of last investigation from BlameInvestigate",
+        desc =
+        "Investigate Git history of selected code block by visually selecting lines. git log -L<start_line>:<end_line>",
     })
 
     vim.api.nvim_create_user_command("BlameInvestigateContent", M.investigate_content, {
@@ -120,7 +138,12 @@ function M.setup()
 
     vim.api.nvim_create_user_command("BlameInvestigateFunction", M.investigate_function_names, {
         range = true,
-        desc = "Investigate git history by identifying function names in selected code block. git log -L:<func_name>:<file_name>",
+        desc =
+        "Investigate git history by identifying function names in selected code block. git log -L:<func_name>:<file_name>",
+    })
+
+    vim.api.nvim_create_user_command("BlameShowLast", M.show_last_investigation, {
+        desc = "Show telescope picker of last investigation from BlameInvestigate",
     })
 end
 

--- a/lua/better-git-blame/init.lua
+++ b/lua/better-git-blame/init.lua
@@ -11,71 +11,79 @@ telescope_integration.setup_dependencies(git_utils)
 --- stores state of last investigation to be able to reopen
 --- with BlameShowLast
 local current_state = {
-    last_selection = nil,   ---@type table|nil selection object from last investigation
-    last_repo_root = nil,   ---@type string|nil repository root from last investigation
-    last_commit_list = nil, ---@type table|nil list of commits from last investigation
-    last_search_term = nil, ---@type string|nil search term used if last search was content based
+	last_selection = nil, ---@type table|nil selection object from last investigation
+	last_repo_root = nil, ---@type string|nil repository root from last investigation
+	last_commit_list = nil, ---@type table|nil list of commits from last investigation
+	last_search_term = nil, ---@type string|nil search term used if last search was content based
 }
 
 ---Investigates the Git history for visually selected line
 ---function for :BlameInvestigateLines
 ---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_lines(args)
-    -- get lines of visual selection
-    local selection = selection_utils.get_visual_selection(args.line1, args.line2)
-    if not selection then return end -- handled in get_visual_selection
+	-- get lines of visual selection
+	local selection = selection_utils.get_visual_selection(args.line1, args.line2)
+	if not selection then
+		return
+	end -- handled in get_visual_selection
 
-    local repo_root = git_utils.find_git_repo_root(selection.filename)
-    if not repo_root then return end -- handled in find_git_repo_root
+	local repo_root = git_utils.find_git_repo_root(selection.filename)
+	if not repo_root then
+		return
+	end -- handled in find_git_repo_root
 
-    -- update cached values for use in :BlameShowLast
-    current_state.last_selection = selection
-    current_state.last_repo_root = repo_root
-    current_state.last_search_term = nil
+	-- update cached values for use in :BlameShowLast
+	current_state.last_selection = selection
+	current_state.last_repo_root = repo_root
+	current_state.last_search_term = nil
 
-    git_utils.get_commits_by_line(selection, repo_root, function(commit_list, err)
-        if err then
-            return -- error handled in get_commits_by_line
-        end
+	git_utils.get_commits_by_line(selection, repo_root, function(commit_list, err)
+		if err then
+			return -- error handled in get_commits_by_line
+		end
 
-        -- update cached commit list
-        current_state.last_commit_list = commit_list
-        local title = string.format("Git History (Lines %d - %d)", selection.start_line, selection.end_line)
-        telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
-    end)
+		-- update cached commit list
+		current_state.last_commit_list = commit_list
+		local title = string.format("Git History (Lines %d - %d)", selection.start_line, selection.end_line)
+		telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
+	end)
 end
 
 ---Investigates the Git history for content matching visually selected text
 ---function for :BlameInvestigateContent
 ---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_content(args)
-    -- get lines of visual selection
-    local selection, lines = selection_utils.get_visual_selection_content(args.line1, args.line2)
-    if not selection then return end
+	-- get lines of visual selection
+	local selection, lines = selection_utils.get_visual_selection_content(args.line1, args.line2)
+	if not selection then
+		return
+	end
 
-    local repo_root = git_utils.find_git_repo_root(selection.filename)
-    if not repo_root then return end -- handled in find_git_repo_root
+	local repo_root = git_utils.find_git_repo_root(selection.filename)
+	if not repo_root then
+		return
+	end -- handled in find_git_repo_root
 
-    local search_term = selection_utils.derive_regex_from_lines(lines)
+	local search_term = selection_utils.derive_regex_from_lines(lines)
 
-    if not search_term or search_term == "" then
-        return
-    end
+	if not search_term or search_term == "" then
+		return
+	end
 
-    -- update cached values for use in :BlameShowLast
-    current_state.last_selection = selection
-    current_state.last_repo_root = repo_root
-    current_state.last_search_term = search_term
+	-- update cached values for use in :BlameShowLast
+	current_state.last_selection = selection
+	current_state.last_repo_root = repo_root
+	current_state.last_search_term = search_term
 
-    git_utils.get_commits_by_search_term(selection, repo_root, search_term, function(commit_list, err)
-        if err then
-            return -- error handled in get_commits_by_search_term
-        end
-        current_state.last_commit_list = commit_list
+	git_utils.get_commits_by_search_term(selection, repo_root, search_term, function(commit_list, err)
+		if err then
+			return -- error handled in get_commits_by_search_term
+		end
+		current_state.last_commit_list = commit_list
 
-        local title = "Git History (Content Search)"
-        telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
-    end)
+		local title = "Git History (Content Search)"
+		telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
+	end)
 end
 
 ---Investigates the Git history by identifying function names in the visually
@@ -83,68 +91,79 @@ end
 ---function for :BlameInvestigateFunction
 ---@param args table command arguments { line1 = number, line2 = number }
 function M.investigate_function_names(args)
-    -- get lines and function names from visual selection
-    local selection, func_names = selection_utils.get_function_names_from_selection(args.line1, args.line2)
-    if not selection or not func_names or #func_names == 0 then return end
+	-- get lines and function names from visual selection
+	local selection, func_names = selection_utils.get_function_names_from_selection(args.line1, args.line2)
+	if not selection or not func_names or #func_names == 0 then
+		return
+	end
 
-    local repo_root = git_utils.find_git_repo_root(selection.filename)
-    if not repo_root then return end -- handled in find_git_repo_root
+	local repo_root = git_utils.find_git_repo_root(selection.filename)
+	if not repo_root then
+		return
+	end -- handled in find_git_repo_root
 
-    current_state.last_selection = selection
-    current_state.last_repo_root = repo_root
-    current_state.last_search_term = nil
+	current_state.last_selection = selection
+	current_state.last_repo_root = repo_root
+	current_state.last_search_term = nil
 
-    git_utils.get_commits_by_func_name(selection, repo_root, func_names, function(commit_list, err)
-        if err then
-            return -- handled in get_commits_by_func_name
-        end
-        current_state.last_commit_list = commit_list
+	git_utils.get_commits_by_func_name(selection, repo_root, func_names, function(commit_list, err)
+		if err then
+			return -- handled in get_commits_by_func_name
+		end
+		current_state.last_commit_list = commit_list
 
-        local title = string.format("Git History (function search)")
-        telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
-    end)
+		local title = string.format("Git History (function search)")
+		telescope_integration.launch_telescope_picker(commit_list, repo_root, selection, title)
+	end)
 end
 
 ---Opens the telescope picker with results of the last investigation
 ---function for :BlameShowLast
 function M.show_last_investigation()
-    if not current_state.last_selection or
-        not current_state.last_repo_root or
-        not current_state.last_commit_list then
-        vim.notify("Not previous investigation stored.", vim.log.levels.WARN, { title = "BetterGitBlame:BlameShowLast" })
-        return
-    end
-    local title = string.format("Git History (%d - %d)", current_state.last_selection.start_line,
-        current_state.last_selection.end_line)
+	if not current_state.last_selection or not current_state.last_repo_root or not current_state.last_commit_list then
+		vim.notify(
+			"Not previous investigation stored.",
+			vim.log.levels.WARN,
+			{ title = "BetterGitBlame:BlameShowLast" }
+		)
+		return
+	end
+	local title = string.format(
+		"Git History (%d - %d)",
+		current_state.last_selection.start_line,
+		current_state.last_selection.end_line
+	)
 
-    telescope_integration.launch_telescope_picker(current_state.last_commit_list, current_state.last_repo_root,
-        current_state.last_selection, title)
+	telescope_integration.launch_telescope_picker(
+		current_state.last_commit_list,
+		current_state.last_repo_root,
+		current_state.last_selection,
+		title
+	)
 end
 
 ---Setups up user commands for BetterGitBlame plugin
 function M.setup()
-    --config = vim.tbl_deep_extend("force", config, user_config or {})
+	--config = vim.tbl_deep_extend("force", config, user_config or {})
 
-    vim.api.nvim_create_user_command("BlameInvestigateLines", M.investigate_lines, {
-        range = true,
-        desc =
-        "Investigate Git history of selected code block by visually selecting lines. git log -L<start_line>:<end_line>",
-    })
+	vim.api.nvim_create_user_command("BlameInvestigateLines", M.investigate_lines, {
+		range = true,
+		desc = "Investigate Git history of selected code block by visually selecting lines. git log -L<start_line>:<end_line>",
+	})
 
-    vim.api.nvim_create_user_command("BlameInvestigateContent", M.investigate_content, {
-        range = true,
-        desc = "Investigate Git history for content similar to selection. git log -G<regex_string>",
-    })
+	vim.api.nvim_create_user_command("BlameInvestigateContent", M.investigate_content, {
+		range = true,
+		desc = "Investigate Git history for content similar to selection. git log -G<regex_string>",
+	})
 
-    vim.api.nvim_create_user_command("BlameInvestigateFunction", M.investigate_function_names, {
-        range = true,
-        desc =
-        "Investigate git history by identifying function names in selected code block. git log -L:<func_name>:<file_name>",
-    })
+	vim.api.nvim_create_user_command("BlameInvestigateFunction", M.investigate_function_names, {
+		range = true,
+		desc = "Investigate git history by identifying function names in selected code block. git log -L:<func_name>:<file_name>",
+	})
 
-    vim.api.nvim_create_user_command("BlameShowLast", M.show_last_investigation, {
-        desc = "Show telescope picker of last investigation from BlameInvestigate",
-    })
+	vim.api.nvim_create_user_command("BlameShowLast", M.show_last_investigation, {
+		desc = "Show telescope picker of last investigation from BlameInvestigate",
+	})
 end
 
 return M

--- a/lua/better-git-blame/selection.lua
+++ b/lua/better-git-blame/selection.lua
@@ -11,11 +11,20 @@ local function_node_types = {
     ["function_definition_statement"] = true,
 }
 
-local function is_function_declaration_node(node)
+---Checks if a Treesitter node represents a function declaration/definition
+---for the current buffer's language
+---@param node userdata Treesitter node to check
+---@return boolean True if node is a function type for the language
+local function is_function_declaration_node(node, lang)
     if not node then return false end
     return function_node_types[node:type()]
 end
 
+---Escapes text to be used as a POSIX Extended Regular Expression (ERE)
+---Escapes characters with special meaning in EREs
+---Also converts sequences of spaces '\s+' to match one or more whitespace characters
+---@param text string the text to escape
+---@return string the escaped string
 local function escape_posix_ere(text)
     if not text then return "" end
 
@@ -35,16 +44,19 @@ local function escape_posix_ere(text)
     text = text:gsub("{", "\\{")
     text = text:gsub("}", "\\}")
     text = text:gsub("|", "\\|")
-    text = text:gsub(" ", "\\s+")
+    text = text:gsub("%s+", "\\s+")
 
     return text
 end
 
--- get the file, start_line, and end_line of visual selection
+---Get the current buffer's filename and the start/end lines of a visual selection
+---@param start_line number starting line number of selection (1-based)
+---@param end_line number ending line number of selection (1-based)
+---@return table|nil vis_selection table { filename = string, start_line = number, end_line = number} or nil on error
 function M.get_visual_selection(start_line, end_line)
     local file_path = vim.fn.expand("%:p")
     if not file_path or file_path == "" then
-        vim.notify("No file name associated with buffer", vim.log.levels.WARN, { title="BetterGitBlame"})
+        vim.notify("No file name associated with buffer", vim.log.levels.WARN, { title = "BetterGitBlame" })
         return nil
     end
 
@@ -53,22 +65,27 @@ function M.get_visual_selection(start_line, end_line)
         start_line, end_line = end_line, start_line
     end
 
-    return { file = file_path, start_line = start_line, end_line = end_line }
+    return { filename = file_path, start_line = start_line, end_line = end_line }
 end
 
--- get the file, start_line, and end_line for the visual selection and the actual lines for that selection
+---Gets visual selection details as well as the actual content of the selection
+---@param start_line number starting line number of selection (1-based)
+---@param end_line number ending line number of selection (1-based)
+---@return table|nil vis_selection table { filename, start_line, end_line }
+---@return table|nil lines of strings with selection lines or nil
 function M.get_visual_selection_content(start_line, end_line)
+    --- TODO move this get_visual_selection to calling function
     local vis_selection = M.get_visual_selection(start_line, end_line)
-    -- check
 
-    local lines = vim.api.nvim_buf_get_lines(0, start_line-1, end_line, false)
+    local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
     if not lines then return nil, nil end
 
     return vis_selection, lines
 end
 
--- pick longest line from selection and use escape__posix_ere to create regex for it
--- a little more fuzzy than searching directly for string
+---Derives a POSIX ERE regex from the longest non-empty trimmed line in the viusal selection
+---@param lines table a list of strings (lines of text from buffer)
+---@return string|nil derived regex string or nil if no suitable line is found
 function M.derive_regex_from_lines(lines)
     if not lines then return nil end
 
@@ -77,7 +94,7 @@ function M.derive_regex_from_lines(lines)
     if lines then
         for _, line in ipairs(lines) do
             local trimmed_line = vim.trim(line)
-            if trimmed_line ~= "" and #trimmed_line > #longest_line then
+            if #trimmed_line > #longest_line then
                 longest_line = trimmed_line
             end
         end
@@ -88,8 +105,7 @@ function M.derive_regex_from_lines(lines)
     end
 
     local final_regex = escape_posix_ere(longest_line)
-
-    if final_regex == "" or not final_regex then
+    if final_regex == "" or not final_regex then -- should not happen
         --fallback to pickaxe
         return nil
     end
@@ -97,15 +113,19 @@ function M.derive_regex_from_lines(lines)
     return final_regex
 end
 
--- get the file, start_line, and end_line for the visual selection and a list of function names in the selection
--- TODO if no function names in selection, try and traverse up tree to find what function we are in.
---      if not in function then return empty list
+---Extracts function names from the current visual selection using Treesitter
+---Attempts to find function definition nodes that intersect with selection
+---If selection does no contain and function definition nodes, it will attempt to identify the closing function
+---@param start_line number starting line number of selection (1-based)
+---@param end_line number ending line number of selection (1-based)
+---@return table|nil vis_selection table { filename, start_line, end_line }
+---@return table|nil function_names list of unique function names strings or nil on error
 function M.get_function_names_from_selection(start_line, end_line)
     local vis_selection = M.get_visual_selection(start_line, end_line)
     if not vis_selection then return nil, nil end
 
     local bufnr = vim.api.nvim_get_current_buf()
-    local parser = ts_parsers.get_parser(bufnr, vim.bo.filetype)
+    local parser = ts_parsers.get_parser(bufnr, vim.bo[bufnr].filetype)
     local tree = parser:parse()[1]
     local root = tree:root()
 
@@ -115,7 +135,7 @@ function M.get_function_names_from_selection(start_line, end_line)
 
     -- hacky but works if visual selection is only line of method declaration
     if target_start_line == target_end_line then
-        target_end_line = target_end_line+1
+        target_end_line = target_end_line + 1
     end
 
     -- TODO move this query string to config somewhere else and work with other languages than lua

--- a/lua/better-git-blame/selection.lua
+++ b/lua/better-git-blame/selection.lua
@@ -7,8 +7,8 @@ local ts_parsers = require("nvim-treesitter.parsers")
 local ts_query = require("vim.treesitter.query")
 
 local function_node_types = {
-    ["function_declaration"] = true,
-    ["function_definition_statement"] = true,
+	["function_declaration"] = true,
+	["function_definition_statement"] = true,
 }
 
 ---Checks if a Treesitter node represents a function declaration/definition
@@ -16,8 +16,10 @@ local function_node_types = {
 ---@param node userdata Treesitter node to check
 ---@return boolean True if node is a function type for the language
 local function is_function_declaration_node(node, lang)
-    if not node then return false end
-    return function_node_types[node:type()]
+	if not node then
+		return false
+	end
+	return function_node_types[node:type()]
 end
 
 ---Escapes text to be used as a POSIX Extended Regular Expression (ERE)
@@ -26,27 +28,29 @@ end
 ---@param text string the text to escape
 ---@return string the escaped string
 local function escape_posix_ere(text)
-    if not text then return "" end
+	if not text then
+		return ""
+	end
 
-    -- escape posix and regex sequences for parsing line into regex
-    -- git grep can read
-    text = text:gsub("\\", "\\\\")
-    text = text:gsub("%^", "\\^")
-    text = text:gsub("%$", "\\$")
-    text = text:gsub("%.", "\\.")
-    text = text:gsub("%[", "\\[")
-    text = text:gsub("%]", "\\]")
-    text = text:gsub("%(", "\\(")
-    text = text:gsub("%)", "\\)")
-    text = text:gsub("%*", "\\*")
-    text = text:gsub("%+", "\\+")
-    text = text:gsub("%?", "\\?")
-    text = text:gsub("{", "\\{")
-    text = text:gsub("}", "\\}")
-    text = text:gsub("|", "\\|")
-    text = text:gsub("%s+", "\\s+")
+	-- escape posix and regex sequences for parsing line into regex
+	-- git grep can read
+	text = text:gsub("\\", "\\\\")
+	text = text:gsub("%^", "\\^")
+	text = text:gsub("%$", "\\$")
+	text = text:gsub("%.", "\\.")
+	text = text:gsub("%[", "\\[")
+	text = text:gsub("%]", "\\]")
+	text = text:gsub("%(", "\\(")
+	text = text:gsub("%)", "\\)")
+	text = text:gsub("%*", "\\*")
+	text = text:gsub("%+", "\\+")
+	text = text:gsub("%?", "\\?")
+	text = text:gsub("{", "\\{")
+	text = text:gsub("}", "\\}")
+	text = text:gsub("|", "\\|")
+	text = text:gsub("%s+", "\\s+")
 
-    return text
+	return text
 end
 
 ---Get the current buffer's filename and the start/end lines of a visual selection
@@ -54,18 +58,18 @@ end
 ---@param end_line number ending line number of selection (1-based)
 ---@return table|nil vis_selection table { filename = string, start_line = number, end_line = number} or nil on error
 function M.get_visual_selection(start_line, end_line)
-    local file_path = vim.fn.expand("%:p")
-    if not file_path or file_path == "" then
-        vim.notify("No file name associated with buffer", vim.log.levels.WARN, { title = "BetterGitBlame" })
-        return nil
-    end
+	local file_path = vim.fn.expand("%:p")
+	if not file_path or file_path == "" then
+		vim.notify("No file name associated with buffer", vim.log.levels.WARN, { title = "BetterGitBlame" })
+		return nil
+	end
 
-    -- handle backward selection
-    if start_line > end_line then
-        start_line, end_line = end_line, start_line
-    end
+	-- handle backward selection
+	if start_line > end_line then
+		start_line, end_line = end_line, start_line
+	end
 
-    return { filename = file_path, start_line = start_line, end_line = end_line }
+	return { filename = file_path, start_line = start_line, end_line = end_line }
 end
 
 ---Gets visual selection details as well as the actual content of the selection
@@ -74,43 +78,47 @@ end
 ---@return table|nil vis_selection table { filename, start_line, end_line }
 ---@return table|nil lines of strings with selection lines or nil
 function M.get_visual_selection_content(start_line, end_line)
-    --- TODO move this get_visual_selection to calling function
-    local vis_selection = M.get_visual_selection(start_line, end_line)
+	--- TODO move this get_visual_selection to calling function
+	local vis_selection = M.get_visual_selection(start_line, end_line)
 
-    local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
-    if not lines then return nil, nil end
+	local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+	if not lines then
+		return nil, nil
+	end
 
-    return vis_selection, lines
+	return vis_selection, lines
 end
 
 ---Derives a POSIX ERE regex from the longest non-empty trimmed line in the viusal selection
 ---@param lines table a list of strings (lines of text from buffer)
 ---@return string|nil derived regex string or nil if no suitable line is found
 function M.derive_regex_from_lines(lines)
-    if not lines then return nil end
+	if not lines then
+		return nil
+	end
 
-    -- pick the longest line of the selection content
-    local longest_line = ""
-    if lines then
-        for _, line in ipairs(lines) do
-            local trimmed_line = vim.trim(line)
-            if #trimmed_line > #longest_line then
-                longest_line = trimmed_line
-            end
-        end
-    end
+	-- pick the longest line of the selection content
+	local longest_line = ""
+	if lines then
+		for _, line in ipairs(lines) do
+			local trimmed_line = vim.trim(line)
+			if #trimmed_line > #longest_line then
+				longest_line = trimmed_line
+			end
+		end
+	end
 
-    if longest_line == "" then
-        return nil
-    end
+	if longest_line == "" then
+		return nil
+	end
 
-    local final_regex = escape_posix_ere(longest_line)
-    if final_regex == "" or not final_regex then -- should not happen
-        --fallback to pickaxe
-        return nil
-    end
+	local final_regex = escape_posix_ere(longest_line)
+	if final_regex == "" or not final_regex then -- should not happen
+		--fallback to pickaxe
+		return nil
+	end
 
-    return final_regex
+	return final_regex
 end
 
 ---Extracts function names from the current visual selection using Treesitter
@@ -121,63 +129,70 @@ end
 ---@return table|nil vis_selection table { filename, start_line, end_line }
 ---@return table|nil function_names list of unique function names strings or nil on error
 function M.get_function_names_from_selection(start_line, end_line)
-    local vis_selection = M.get_visual_selection(start_line, end_line)
-    if not vis_selection then return nil, nil end
+	local vis_selection = M.get_visual_selection(start_line, end_line)
+	if not vis_selection then
+		return nil, nil
+	end
 
-    local bufnr = vim.api.nvim_get_current_buf()
-    local parser = ts_parsers.get_parser(bufnr, vim.bo[bufnr].filetype)
-    local tree = parser:parse()[1]
-    local root = tree:root()
+	local bufnr = vim.api.nvim_get_current_buf()
+	local parser = ts_parsers.get_parser(bufnr, vim.bo[bufnr].filetype)
+	local tree = parser:parse()[1]
+	local root = tree:root()
 
-    -- to zero-based
-    local target_start_line = vis_selection.start_line - 1
-    local target_end_line = vis_selection.end_line - 1
+	-- to zero-based
+	local target_start_line = vis_selection.start_line - 1
+	local target_end_line = vis_selection.end_line - 1
 
-    -- hacky but works if visual selection is only line of method declaration
-    if target_start_line == target_end_line then
-        target_end_line = target_end_line + 1
-    end
+	-- hacky but works if visual selection is only line of method declaration
+	if target_start_line == target_end_line then
+		target_end_line = target_end_line + 1
+	end
 
-    -- TODO move this query string to config somewhere else and work with other languages than lua
-    local query_str = [[
+	-- TODO move this query string to config somewhere else and work with other languages than lua
+	local query_str = [[
         (function_declaration name: (identifier) @func_name)
         (function_declaration name: (dot_index_expression) @func_name)
     ]]
 
-    local query = ts_query.parse(vim.bo.filetype, query_str)
+	local query = ts_query.parse(vim.bo.filetype, query_str)
 
-    local current_node = root:descendant_for_range(target_start_line, target_end_line, target_start_line, target_end_line)
+	local current_node =
+		root:descendant_for_range(target_start_line, target_end_line, target_start_line, target_end_line)
 
-    if not current_node then
-        print("Could not find node at selection start.")
-        return nil, nil
-    end
+	if not current_node then
+		print("Could not find node at selection start.")
+		return nil, nil
+	end
 
-    -- getting parent function_declaration from selection text
-    while current_node do
-        if is_function_declaration_node(current_node) then
-            local body_start_line, _, body_end_line, _ = current_node:range()
+	-- getting parent function_declaration from selection text
+	while current_node do
+		if is_function_declaration_node(current_node) then
+			local body_start_line, _, body_end_line, _ = current_node:range()
 
-            if body_start_line < target_start_line then target_start_line = body_start_line end
-            -- dont really need to update end
-            if body_end_line > target_end_line then target_end_line = body_end_line end
-        end
-        current_node = current_node:parent()
-    end
+			if body_start_line < target_start_line then
+				target_start_line = body_start_line
+			end
+			-- dont really need to update end
+			if body_end_line > target_end_line then
+				target_end_line = body_end_line
+			end
+		end
+		current_node = current_node:parent()
+	end
 
-    local names = {}
-    local name_set = {}
+	local names = {}
+	local name_set = {}
 
-    for id, node, metadata in query:iter_captures(root, bufnr, target_start_line, target_end_line) do
-        -- id and metadata unused for now, but they are options for later maybe
-        local name = vim.treesitter.get_node_text(node, 0)
-        if not name_set[name] then
-            table.insert(names, name)
-            name_set[name] = true
-        end
-    end
+	for id, node, metadata in query:iter_captures(root, bufnr, target_start_line, target_end_line) do
+		-- id and metadata unused for now, but they are options for later maybe
+		local name = vim.treesitter.get_node_text(node, 0)
+		if not name_set[name] then
+			table.insert(names, name)
+			name_set[name] = true
+		end
+	end
 
-    return vis_selection, names
+	return vis_selection, names
 end
 
 return M

--- a/lua/better-git-blame/telescope.lua
+++ b/lua/better-git-blame/telescope.lua
@@ -12,60 +12,62 @@ local git_utils
 ---sets up dependencies for telescope integration
 ---@param utils table better-git-blame.utils module
 function M.setup_dependencies(utils)
-    git_utils = utils
+	git_utils = utils
 end
 
 ---Create a Telescope previewer for displaying git commit diffs
 ---@param repo_root string absolute path to git repo root
 ---@return table Telescope previewer table instance
 local function create_previewer(repo_root)
-    return previewers.new_buffer_previewer({
-        define_preview = function(self, entry, status)
-            if not vim.api.nvim_buf_is_valid(self.state.bufnr) then
-                return
-            end
+	return previewers.new_buffer_previewer({
+		define_preview = function(self, entry, status)
+			if not vim.api.nvim_buf_is_valid(self.state.bufnr) then
+				return
+			end
 
-            local bufnr = self.state.bufnr
+			local bufnr = self.state.bufnr
 
-            -- set buffer modifiable and clear it
-            vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
-            vim.api.nvim_buf_set_option(bufnr, "readonly", false)
-            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
+			-- set buffer modifiable and clear it
+			vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+			vim.api.nvim_buf_set_option(bufnr, "readonly", false)
+			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
 
-            -- filetype git
-            vim.api.nvim_buf_set_option(bufnr, "filetype", "git")
+			-- filetype git
+			vim.api.nvim_buf_set_option(bufnr, "filetype", "git")
 
-            if not entry or not entry.value or not entry.value.hash then
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Error: Invalid entry", vim.inspect(entry) })
-                vim.api.nvim_buf_set_option(bufnr, "readonly", true)
-                vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-                return
-            end
+			if not entry or not entry.value or not entry.value.hash then
+				vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Error: Invalid entry", vim.inspect(entry) })
+				vim.api.nvim_buf_set_option(bufnr, "readonly", true)
+				vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+				return
+			end
 
-            local commit_hash = entry.value.hash
-            git_utils.get_commit_details(repo_root, commit_hash, function(diff_lines, error_lines, exit_code)
-                -- check buffer validity since async callback
-                if not vim.api.nvim_buf_is_valid(bufnr) then return end
+			local commit_hash = entry.value.hash
+			git_utils.get_commit_details(repo_root, commit_hash, function(diff_lines, error_lines, exit_code)
+				-- check buffer validity since async callback
+				if not vim.api.nvim_buf_is_valid(bufnr) then
+					return
+				end
 
-                local final_content
-                if exit_code ~= 0 then
-                    final_content = error_lines
-                else
-                    final_content = diff_lines
-                end
+				local final_content
+				if exit_code ~= 0 then
+					final_content = error_lines
+				else
+					final_content = diff_lines
+				end
 
-                vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
-                vim.api.nvim_buf_set_option(bufnr, "readonly", false)
+				vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+				vim.api.nvim_buf_set_option(bufnr, "readonly", false)
 
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, final_content)
+				vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, final_content)
 
-                vim.api.nvim_buf_set_option(bufnr, "readonly", true)
-                vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+				vim.api.nvim_buf_set_option(bufnr, "readonly", true)
+				vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
 
-                vim.api.nvim_win_set_cursor(self.state.winid, { 1, 0 })
-            end)
-        end,
-    })
+				vim.api.nvim_win_set_cursor(self.state.winid, { 1, 0 })
+			end)
+		end,
+	})
 end
 
 ---Launches telescope picker to display list of commits
@@ -74,77 +76,84 @@ end
 ---@param selection table visual selection object { filename, start_line, end_line }
 ---@param title string|nil title for telescope prompt
 function M.launch_telescope_picker(commit_list, repo_root, selection, title)
-    pickers.new({}, {
-        prompt_title = title or "BetterGitBlame",
-        finder = finders.new_table({
-            results = commit_list,
-            entry_maker = function(entry)
-                -- trim hash to first 6 characters
-                local trimmed_hash = string.sub(entry.hash, 1, 7)
+	pickers
+		.new({}, {
+			prompt_title = title or "BetterGitBlame",
+			finder = finders.new_table({
+				results = commit_list,
+				entry_maker = function(entry)
+					-- trim hash to first 6 characters
+					local trimmed_hash = string.sub(entry.hash, 1, 7)
 
-                return {
-                    value = entry,
-                    display = string.format("%s (%s %s) | %s | %s",
-                        trimmed_hash,
-                        entry.date,
-                        entry.time,
-                        entry.author,
-                        entry.message),
-                    ordinal = entry.date .. " " .. entry.time,
-                }
-            end
-        }),
-        -- use generic_sorter with fuzzy matching
-        sorter = sorters.get_generic_fuzzy_sorter({}),
-        previewer = create_previewer(repo_root),
-        layout_strategy = 'horizontal',
-        layout_config = {
-            horizontal = {
-                preview_width = 0.5,
-            }
-        },
-        -- mappings
-        attach_mappings = function(prompt_bufnr, map)
-            -- local current_picker = action_state.get_current_picker(prompt_bufnr)
+					return {
+						value = entry,
+						display = string.format(
+							"%s (%s %s) | %s | %s",
+							trimmed_hash,
+							entry.date,
+							entry.time,
+							entry.author,
+							entry.message
+						),
+						ordinal = entry.date .. " " .. entry.time,
+					}
+				end,
+			}),
+			-- use generic_sorter with fuzzy matching
+			sorter = sorters.get_generic_fuzzy_sorter({}),
+			previewer = create_previewer(repo_root),
+			layout_strategy = "horizontal",
+			layout_config = {
+				horizontal = {
+					preview_width = 0.5,
+				},
+			},
+			-- mappings
+			attach_mappings = function(prompt_bufnr, map)
+				-- local current_picker = action_state.get_current_picker(prompt_bufnr)
 
-            -- default action: show diff of selected commit
-            actions.select_default:replace(function()
-                local current_sel = action_state.get_selected_entry()
-                actions.close(prompt_bufnr)
+				-- default action: show diff of selected commit
+				actions.select_default:replace(function()
+					local current_sel = action_state.get_selected_entry()
+					actions.close(prompt_bufnr)
 
-                if current_sel and current_sel.value and current_sel.value.hash then
-                    local hash = current_sel.value.hash
-                    local file = current_sel.filename
+					if current_sel and current_sel.value and current_sel.value.hash then
+						local hash = current_sel.value.hash
+						local file = current_sel.filename
 
-                    -- where optional dependencies come in handy
+						-- where optional dependencies come in handy
 
-                    if vim.fn.exists(":Gvdiffsplit") == 2 then      -- fugitive
-                        vim.cmd("Gvdiffsplit " .. hash)
-                    elseif vim.fn.exists(":DiffviewOpen") == 2 then --diffview
-                        vim.cmd("DiffviewOpen " .. hash .. ".." .. hash .. " -- " .. file)
-                    else
-                        if vim.fn.exists(":Git") == 2 then
-                            vim.cmd("tab Git show " .. hash)
-                        else
-                            vim.cmd("tabnew | term git -C " .. vim.fn.shellescape(repo_root) .. " show " .. hash)
-                        end
-                    end
-                end
-            end)
-            -- TODO commands to change diff view between HEAD, parent, working,
-            -- Ctrl+b in telescope picker to open commit in browser
-            map({ "i", "n" }, "<C-b>", function()
-                local current_sel = action_state.get_selected_entry()
-                if current_sel and current_sel.value and current_sel.value.hash then
-                    git_utils.open_commit_in_browser(repo_root, current_sel.value.hash)
-                else
-                    vim.notify("No valid commit selected to open", vim.log.levels.WARN,
-                        { title = "BetterGitBlame:OpenCommitInBrowser" })
-                end
-            end)
-            return true
-        end
-    }):find()
+						if vim.fn.exists(":Gvdiffsplit") == 2 then -- fugitive
+							vim.cmd("Gvdiffsplit " .. hash)
+						elseif vim.fn.exists(":DiffviewOpen") == 2 then --diffview
+							vim.cmd("DiffviewOpen " .. hash .. ".." .. hash .. " -- " .. file)
+						else
+							if vim.fn.exists(":Git") == 2 then
+								vim.cmd("tab Git show " .. hash)
+							else
+								vim.cmd("tabnew | term git -C " .. vim.fn.shellescape(repo_root) .. " show " .. hash)
+							end
+						end
+					end
+				end)
+				-- TODO commands to change diff view between HEAD, parent, working,
+				-- Ctrl+b in telescope picker to open commit in browser
+				map({ "i", "n" }, "<C-b>", function()
+					local current_sel = action_state.get_selected_entry()
+					if current_sel and current_sel.value and current_sel.value.hash then
+						git_utils.open_commit_in_browser(repo_root, current_sel.value.hash)
+					else
+						vim.notify(
+							"No valid commit selected to open",
+							vim.log.levels.WARN,
+							{ title = "BetterGitBlame:OpenCommitInBrowser" }
+						)
+					end
+				end)
+				return true
+			end,
+		})
+		:find()
 end
 
 return M

--- a/lua/better-git-blame/telescope.lua
+++ b/lua/better-git-blame/telescope.lua
@@ -1,9 +1,7 @@
 -- lua/better-git-blame/telescope.lua
 local M = {}
-local Path = require("plenary.path")
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
--- local conf  = require("telescope.config").values
 local sorters = require("telescope.sorters")
 local previewers = require("telescope.previewers")
 local actions = require("telescope.actions")
@@ -11,12 +9,15 @@ local action_state = require("telescope.actions.state")
 
 local git_utils
 
+---sets up dependencies for telescope integration
+---@param utils table better-git-blame.utils module
 function M.setup_dependencies(utils)
     git_utils = utils
 end
 
-
--- defining preview window
+---Create a Telescope previewer for displaying git commit diffs
+---@param repo_root string absolute path to git repo root
+---@return table Telescope previewer table instance
 local function create_previewer(repo_root)
     return previewers.new_buffer_previewer({
         define_preview = function(self, entry, status)
@@ -29,23 +30,21 @@ local function create_previewer(repo_root)
             -- set buffer modifiable and clear it
             vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
             vim.api.nvim_buf_set_option(bufnr, "readonly", false)
+            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
 
             -- filetype git
             vim.api.nvim_buf_set_option(bufnr, "filetype", "git")
 
-            -- clear buffer
-            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
-
             if not entry or not entry.value or not entry.value.hash then
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Error: Invalid entry", vim.inspect(entry)})
+                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "Error: Invalid entry", vim.inspect(entry) })
                 vim.api.nvim_buf_set_option(bufnr, "readonly", true)
                 vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
                 return
             end
 
             local commit_hash = entry.value.hash
-
             git_utils.get_commit_details(repo_root, commit_hash, function(diff_lines, error_lines, exit_code)
+                -- check buffer validity since async callback
                 if not vim.api.nvim_buf_is_valid(bufnr) then return end
 
                 local final_content
@@ -63,29 +62,39 @@ local function create_previewer(repo_root)
                 vim.api.nvim_buf_set_option(bufnr, "readonly", true)
                 vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
 
-                vim.api.nvim_win_set_cursor(self.state.winid, {1, 0})
+                vim.api.nvim_win_set_cursor(self.state.winid, { 1, 0 })
             end)
         end,
     })
 end
 
+---Launches telescope picker to display list of commits
+---@param commit_list table list of commits (utils.parse_git_log)
+---@param repo_root string absolute path to git repo root
+---@param selection table visual selection object { filename, start_line, end_line }
+---@param title string|nil title for telescope prompt
 function M.launch_telescope_picker(commit_list, repo_root, selection, title)
     pickers.new({}, {
         prompt_title = title or "BetterGitBlame",
         finder = finders.new_table({
             results = commit_list,
             entry_maker = function(entry)
-
                 -- trim hash to first 6 characters
                 local trimmed_hash = string.sub(entry.hash, 1, 7)
 
                 return {
                     value = entry,
-                    display = string.format("%s (%s %s) | %s | %s", trimmed_hash, entry.date, entry.time, entry.author, entry.message),
+                    display = string.format("%s (%s %s) | %s | %s",
+                        trimmed_hash,
+                        entry.date,
+                        entry.time,
+                        entry.author,
+                        entry.message),
                     ordinal = entry.date .. " " .. entry.time,
                 }
             end
         }),
+        -- use generic_sorter with fuzzy matching
         sorter = sorters.get_generic_fuzzy_sorter({}),
         previewer = create_previewer(repo_root),
         layout_strategy = 'horizontal',
@@ -95,21 +104,21 @@ function M.launch_telescope_picker(commit_list, repo_root, selection, title)
             }
         },
         -- mappings
-        -- map can be used for later keybind functionality
         attach_mappings = function(prompt_bufnr, map)
             -- local current_picker = action_state.get_current_picker(prompt_bufnr)
 
+            -- default action: show diff of selected commit
             actions.select_default:replace(function()
-                local sel = action_state.get_selected_entry()
+                local current_sel = action_state.get_selected_entry()
                 actions.close(prompt_bufnr)
 
-                if sel and sel.value and sel.value.hash then
-                    local hash = sel.value.hash
-                    local file = sel.filename
+                if current_sel and current_sel.value and current_sel.value.hash then
+                    local hash = current_sel.value.hash
+                    local file = current_sel.filename
 
                     -- where optional dependencies come in handy
 
-                    if vim.fn.exists(":Gvdiffsplit") == 2 then -- fugitive
+                    if vim.fn.exists(":Gvdiffsplit") == 2 then      -- fugitive
                         vim.cmd("Gvdiffsplit " .. hash)
                     elseif vim.fn.exists(":DiffviewOpen") == 2 then --diffview
                         vim.cmd("DiffviewOpen " .. hash .. ".." .. hash .. " -- " .. file)
@@ -124,18 +133,18 @@ function M.launch_telescope_picker(commit_list, repo_root, selection, title)
             end)
             -- TODO commands to change diff view between HEAD, parent, working,
             -- Ctrl+b in telescope picker to open commit in browser
-            map({"i", "n"}, "<C-b>", function()
-                local sel = action_state.get_selected_entry()
-                if sel and sel.value and sel.value.hash then
-                    git_utils.open_commit_in_browser(repo_root, sel.value.hash)
+            map({ "i", "n" }, "<C-b>", function()
+                local current_sel = action_state.get_selected_entry()
+                if current_sel and current_sel.value and current_sel.value.hash then
+                    git_utils.open_commit_in_browser(repo_root, current_sel.value.hash)
                 else
-                    vim.notify("No valid commit selected to open", vim.log.levels.WARN, { title="BetterGitBlame:OpenCommitInBrowser" })
+                    vim.notify("No valid commit selected to open", vim.log.levels.WARN,
+                        { title = "BetterGitBlame:OpenCommitInBrowser" })
                 end
             end)
             return true
         end
     }):find()
 end
-
 
 return M


### PR DESCRIPTION
fix typo in plenary dependency
#4 `"nvim-lua-plenary/nvim",` -> `"nvim-lua/plenary.nvim"`


fix typo in init.lua for BlameInvestigateLines command call
#5 `vim.api.nvim_create_user_command("BlameInvestigatLines", M.investigate_lines,` -> `vim.api.nvim_create_user_command("BlameInvestigateLines", M.investigate_lines,`